### PR TITLE
Introduced Makeblock.h header file for referencing the library

### DIFF
--- a/examples/Firmware_For_mBlock/four_in_one_firmware/four_in_one_firmware.ino
+++ b/examples/Firmware_For_mBlock/four_in_one_firmware/four_in_one_firmware.ino
@@ -49,11 +49,14 @@
 #if defined(PRO_ME_BASEBOARD)
 #include <MeBaseBoard.h>
 #elif defined(PRO_ME_ORION)
-#include <MeOrion.h>
+#define MeOrion_H
+#include <Makeblock.h>
 #elif defined(PRO_ME_CORE)
-#include <MeMCore.h>
+#define MeMCore_H
+#include <Makeblock.h>
 #elif defined(PRO_ME_SHIELD)
-#include <MeShield.h>
+#define MeShield_H
+#include <Makeblock.h>
 #endif
 
 MeDCMotor dc;

--- a/examples/Firmware_For_mBlock/mbot_factory_firmware/mbot_factory_firmware.ino
+++ b/examples/Firmware_For_mBlock/mbot_factory_firmware/mbot_factory_firmware.ino
@@ -11,7 +11,8 @@
 **************************************************************************/
 #include <Wire.h>
 #include <SoftwareSerial.h>
-#include <MeMCore.h>
+#define MeMCore_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 MeRGBLed rgb(0,16);

--- a/examples/Firmware_For_mBlock/mbot_firmware/mbot_firmware.ino
+++ b/examples/Firmware_For_mBlock/mbot_firmware/mbot_firmware.ino
@@ -10,7 +10,8 @@
 * http://www.makeblock.cc/
 **************************************************************************/
 #include <Wire.h>
-#include <MeMCore.h>
+#define MeMCore_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 Servo servos[8];  

--- a/examples/Firmware_For_mBlock/orion_firmware/orion_firmware.ino
+++ b/examples/Firmware_For_mBlock/orion_firmware/orion_firmware.ino
@@ -12,7 +12,8 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 #include <Arduino.h>
-#include <MeOrion.h>
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 Servo servos[8];  

--- a/examples/Firmware_For_mBlock/shield_firmware/shield_firmware.ino
+++ b/examples/Firmware_For_mBlock/shield_firmware/shield_firmware.ino
@@ -12,7 +12,8 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 #include <Arduino.h>
-#include <MeShield.h>
+#define MeShield_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 Servo servos[8];  

--- a/examples/Firmware_for_Starter/BlueTooth_Ultrasonic/BlueTooth_Ultrasonic.ino
+++ b/examples/Firmware_for_Starter/BlueTooth_Ultrasonic/BlueTooth_Ultrasonic.ino
@@ -12,7 +12,8 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 #include <Arduino.h>
-#include <MeOrion.h>
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 Servo servos[8];  

--- a/examples/Firmware_for_Starter/IR_Ultrasonic/IR_Ultrasonic.ino
+++ b/examples/Firmware_for_Starter/IR_Ultrasonic/IR_Ultrasonic.ino
@@ -12,7 +12,8 @@
 #include <Wire.h>
 #include <SoftwareSerial.h>
 #include <Arduino.h>
-#include <MeOrion.h>
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 MeDCMotor dc;

--- a/examples/Me_4Button/Me4ButtonTest/Me4ButtonTest.ino
+++ b/examples/Me_4Button/Me4ButtonTest/Me4ButtonTest.ino
@@ -18,7 +18,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include <MeOrion.h>
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 

--- a/examples/Me_7SegmentDisplay/NumberDisplay/NumberDisplay.ino
+++ b/examples/Me_7SegmentDisplay/NumberDisplay/NumberDisplay.ino
@@ -16,7 +16,8 @@
  * Rafael Lee       2015/09/10     1.0.1            Added some comments and macros.
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 Me7SegmentDisplay disp(PORT_6);
 

--- a/examples/Me_7SegmentDisplay/NumberFlow/NumberFlow.ino
+++ b/examples/Me_7SegmentDisplay/NumberFlow/NumberFlow.ino
@@ -21,7 +21,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 Me7SegmentDisplay disp(PORT_6);

--- a/examples/Me_7SegmentDisplay/TimeDisplay/TimeDisplay.ino
+++ b/examples/Me_7SegmentDisplay/TimeDisplay/TimeDisplay.ino
@@ -20,7 +20,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 uint8_t		TimeDisp[] = { 0x00, 0x00, 0x00, 0x00 };
 unsigned char	second;

--- a/examples/Me_Bluetooth/SlaveBluetoothBySoftSerialTest/SlaveBluetoothBySoftSerialTest.ino
+++ b/examples/Me_Bluetooth/SlaveBluetoothBySoftSerialTest/SlaveBluetoothBySoftSerialTest.ino
@@ -25,7 +25,8 @@
  * </pre>
  */
  
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeBluetooth bluetooth(PORT_3);

--- a/examples/Me_Buzzer/BuzzerTest/BuzzerTest.ino
+++ b/examples/Me_Buzzer/BuzzerTest/BuzzerTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan         2015/07/24     1.0.0            Rebuild the old lib.
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 void setup() 
 {

--- a/examples/Me_Buzzer/MbotBuzzerTest2/MbotBuzzerTest2.ino
+++ b/examples/Me_Buzzer/MbotBuzzerTest2/MbotBuzzerTest2.ino
@@ -20,7 +20,8 @@
 /*************************************************
  * Public Constants
  *************************************************/
-#include <MeMCore.h>
+#define MeMCore_H
+#include <Makeblock.h>
 
 #define NOTE_B0  31
 #define NOTE_C1  33

--- a/examples/Me_Compass/MeCompassTest/MeCompassTest.ino
+++ b/examples/Me_Compass/MeCompassTest/MeCompassTest.ino
@@ -17,7 +17,8 @@
  * </pre>
  *
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 
 MeCompass Compass(PORT_4);

--- a/examples/Me_DCMotor/DCMotorDriverTest/DCMotorDriverTest.ino
+++ b/examples/Me_DCMotor/DCMotorDriverTest/DCMotorDriverTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/09    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeDCMotor motor1(PORT_1);
 

--- a/examples/Me_EncoderDriver_New/EncoderMotorTestMoveTo/EncoderMotorTestMoveTo.ino
+++ b/examples/Me_EncoderDriver_New/EncoderMotorTestMoveTo/EncoderMotorTestMoveTo.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_New/EncoderMotorTestRunSpeed/EncoderMotorTestRunSpeed.ino
+++ b/examples/Me_EncoderDriver_New/EncoderMotorTestRunSpeed/EncoderMotorTestRunSpeed.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_New/EncoderMotorTestRunSpeedAndTime/EncoderMotorTestRunSpeedAndTime.ino
+++ b/examples/Me_EncoderDriver_New/EncoderMotorTestRunSpeedAndTime/EncoderMotorTestRunSpeedAndTime.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_New/EncoderMotorTestRunTurns/EncoderMotorTestRunTurns.ino
+++ b/examples/Me_EncoderDriver_New/EncoderMotorTestRunTurns/EncoderMotorTestRunTurns.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_Old/EncoderMotorTestMoveTo/EncoderMotorTestMoveTo.ino
+++ b/examples/Me_EncoderDriver_Old/EncoderMotorTestMoveTo/EncoderMotorTestMoveTo.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_Old/EncoderMotorTestRunSpeed/EncoderMotorTestRunSpeed.ino
+++ b/examples/Me_EncoderDriver_Old/EncoderMotorTestRunSpeed/EncoderMotorTestRunSpeed.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_Old/EncoderMotorTestRunSpeedAndTime/EncoderMotorTestRunSpeedAndTime.ino
+++ b/examples/Me_EncoderDriver_Old/EncoderMotorTestRunSpeedAndTime/EncoderMotorTestRunSpeedAndTime.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_EncoderDriver_Old/EncoderMotorTestRunTurns/EncoderMotorTestRunTurns.ino
+++ b/examples/Me_EncoderDriver_Old/EncoderMotorTestRunTurns/EncoderMotorTestRunTurns.ino
@@ -18,7 +18,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 #include <SoftwareSerial.h>
 

--- a/examples/Me_FlameSensor/MeFlameSensorTest/MeFlameSensorTest.ino
+++ b/examples/Me_FlameSensor/MeFlameSensorTest/MeFlameSensorTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/09    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeFlameSensor FlameSensor1(PORT_8);
 

--- a/examples/Me_GasSensor/MeGasSensorTest/MeGasSensorTest.ino
+++ b/examples/Me_GasSensor/MeGasSensorTest/MeGasSensorTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/09    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeGasSensor GasSensor1(PORT_8);
 

--- a/examples/Me_Gyro/MeGyroTest/MeGyroTest.ino
+++ b/examples/Me_Gyro/MeGyroTest/MeGyroTest.ino
@@ -20,7 +20,8 @@
  * </pre>
  *
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Wire.h>
 
 MeGyro gyro;

--- a/examples/Me_HumitureSensor/MeHumitureSensorTest1/MeHumitureSensorTest1.ino
+++ b/examples/Me_HumitureSensor/MeHumitureSensorTest1/MeHumitureSensorTest1.ino
@@ -17,7 +17,8 @@
  * Mark Yan     2015/09/07    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeHumiture humiture(PORT_6);
 

--- a/examples/Me_HumitureSensor/MeHumitureSensorTest2/MeHumitureSensorTest2.ino
+++ b/examples/Me_HumitureSensor/MeHumitureSensorTest2/MeHumitureSensorTest2.ino
@@ -22,7 +22,8 @@
  * forfish      2015/11/18    1.0.1          Add some functions.
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeHumiture humiture(PORT_6);
 

--- a/examples/Me_InfraredReceiver/InfraredReceiverTest/InfraredReceiverTest.ino
+++ b/examples/Me_InfraredReceiver/InfraredReceiverTest/InfraredReceiverTest.ino
@@ -18,7 +18,8 @@
  * Mark Yan     2015/09/01    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeInfraredReceiver infraredReceiverDecode(PORT_6);

--- a/examples/Me_Joystick/MeJoystickTest/MeJoystickTest.ino
+++ b/examples/Me_Joystick/MeJoystickTest/MeJoystickTest.ino
@@ -19,7 +19,8 @@
  * Mark Yan     2015/09/01    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeJoystick joystick(PORT_6);
 

--- a/examples/Me_LEDMatrix/Me_LEDMatrixTest/Me_LEDMatrixTest.ino
+++ b/examples/Me_LEDMatrix/Me_LEDMatrixTest/Me_LEDMatrixTest.ino
@@ -19,7 +19,8 @@
  * Mark Yan     2016/01/27    1.0.1          add digital printing
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeLEDMatrix ledMx(PORT_4);
 

--- a/examples/Me_LightSensor/MeLightSensorTest/MeLightSensorTest.ino
+++ b/examples/Me_LightSensor/MeLightSensorTest/MeLightSensorTest.ino
@@ -18,7 +18,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 MeLightSensor lightSensor(PORT_6);

--- a/examples/Me_LightSensor/MeLightSensorTestResetPort/MeLightSensorTestResetPort.ino
+++ b/examples/Me_LightSensor/MeLightSensorTestResetPort/MeLightSensorTestResetPort.ino
@@ -21,7 +21,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 //Instantiate class MeLightSensor

--- a/examples/Me_LightSensor/MeLightSensorTestWithLEDon/MeLightSensorTestWithLEDon.ino
+++ b/examples/Me_LightSensor/MeLightSensorTestWithLEDon/MeLightSensorTestWithLEDon.ino
@@ -19,7 +19,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 MeLightSensor lightSensor(PORT_6);

--- a/examples/Me_LimitSwitch/LimitSwitchTest/LimitSwitchTest.ino
+++ b/examples/Me_LimitSwitch/LimitSwitchTest/LimitSwitchTest.ino
@@ -18,7 +18,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 // Me_LimitSwitch module can only be connected to PORT_3, PORT_4, PORT_6, PORT_7, 

--- a/examples/Me_LimitSwitch/MicroSwitchTest/MicroSwitchTest.ino
+++ b/examples/Me_LimitSwitch/MicroSwitchTest/MicroSwitchTest.ino
@@ -18,7 +18,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private functions ---------------------------------------------------------*/
 /* Me_LimitSwitch module can only be connected to PORT_3, PORT_4, PORT_6, 

--- a/examples/Me_LineFollower/LineFollowerTest/LineFollowerTest.ino
+++ b/examples/Me_LineFollower/LineFollowerTest/LineFollowerTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan         2015/09/09    1.0.0            Rebuild the old lib.
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeLineFollower lineFinder(PORT_3); /* Line Finder module can only be connected to PORT_3, PORT_4, PORT_5, PORT_6 of base shield. */
 

--- a/examples/Me_PIRMotionSensor/PIRMotionSensorTest/PIRMotionSensorTest.ino
+++ b/examples/Me_PIRMotionSensor/PIRMotionSensorTest/PIRMotionSensorTest.ino
@@ -19,7 +19,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 MePIRMotionSensor myPIRsensor(PORT_3);

--- a/examples/Me_Potentiometer/PotentiometerTest/PotentiometerTest.ino
+++ b/examples/Me_Potentiometer/PotentiometerTest/PotentiometerTest.ino
@@ -18,7 +18,8 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 /* Private variables ---------------------------------------------------------*/
 MePotentiometer myPotentiometer(PORT_6);

--- a/examples/Me_RGBLed/ColorLoopTest/ColorLoopTest.ino
+++ b/examples/Me_RGBLed/ColorLoopTest/ColorLoopTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan     2015/09/02    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeRGBLed led(PORT_3);
 

--- a/examples/Me_RGBLed/IndicatorsTest/IndicatorsTest.ino
+++ b/examples/Me_RGBLed/IndicatorsTest/IndicatorsTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan     2015/09/02    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeRGBLed led(PORT_3);
 

--- a/examples/Me_RGBLed/WhiteBreathLightTest/WhiteBreathLightTest.ino
+++ b/examples/Me_RGBLed/WhiteBreathLightTest/WhiteBreathLightTest.ino
@@ -16,7 +16,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeRGBLed led1(PORT_3, SLOT1, 15);   /* parameter description: port, slot, led number */
 MeRGBLed led2(PORT_3, SLOT2, 15);

--- a/examples/Me_RJ25Adapter/TestRJ25Adapter/TestRJ25Adapter.ino
+++ b/examples/Me_RJ25Adapter/TestRJ25Adapter/TestRJ25Adapter.ino
@@ -16,7 +16,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MePort output(PORT_4);
 

--- a/examples/Me_Serial/MeSerialReceiveTest/MeSerialReceiveTest.ino
+++ b/examples/Me_Serial/MeSerialReceiveTest/MeSerialReceiveTest.ino
@@ -23,7 +23,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 unsigned char table[128] = {0};

--- a/examples/Me_Serial/MeSerialTransmitTest/MeSerialTransmitTest.ino
+++ b/examples/Me_Serial/MeSerialTransmitTest/MeSerialTransmitTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/09    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeSerial mySerial(PORT_8);

--- a/examples/Me_Servo/Knob/Knob.ino
+++ b/examples/Me_Servo/Knob/Knob.ino
@@ -17,7 +17,8 @@
  * Mark Yan     2015/09/02    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 MePort port(PORT_3);

--- a/examples/Me_Servo/TestServo/TestServo.ino
+++ b/examples/Me_Servo/TestServo/TestServo.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/02    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <Servo.h>
 
 //Parts required:Me RJ25 Adapter and two servo 	

--- a/examples/Me_Shutter/MeShutterTest/MeShutterTest.ino
+++ b/examples/Me_Shutter/MeShutterTest/MeShutterTest.ino
@@ -18,7 +18,8 @@
  * Mark Yan     2015/09/01    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 // MeShutter module can only be connected to the PORT_3, PORT_4, PORT_6 on Orion board
 MeShutter myshutter(PORT3);

--- a/examples/Me_SoundSensor/SoundSensorTest/SoundSensorTest.ino
+++ b/examples/Me_SoundSensor/SoundSensorTest/SoundSensorTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan     2015/09/01    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeSoundSensor mySound(PORT_6);
 

--- a/examples/Me_StepperMotor/SerialControlStepper/SerialControlStepper.ino
+++ b/examples/Me_StepperMotor/SerialControlStepper/SerialControlStepper.ino
@@ -22,7 +22,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeStepper stepper(PORT_1); 

--- a/examples/Me_StepperMotor/TestStepperDriver/TestStepperDriver.ino
+++ b/examples/Me_StepperMotor/TestStepperDriver/TestStepperDriver.ino
@@ -16,7 +16,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 int dirPin = mePort[PORT_1].s1;//the direction pin connect to Base Board PORT1 SLOT1
 int stpPin = mePort[PORT_1].s2;//the Step pin connect to Base Board PORT1 SLOT2

--- a/examples/Me_TFT/MeTFT/MeTFT.ino
+++ b/examples/Me_TFT/MeTFT/MeTFT.ino
@@ -14,7 +14,8 @@
  * Mark Yan         2015/11/10     1.0.0                   
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeSerial mySerial(PORT_5);

--- a/examples/Me_Temperature/TemperatureTest/TemperatureTest.ino
+++ b/examples/Me_Temperature/TemperatureTest/TemperatureTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan     2015/09/07    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeTemperature myTemp(PORT_8, SLOT2);
 

--- a/examples/Me_TouchSensor/TouchSensorTest/TouchSensorTest.ino
+++ b/examples/Me_TouchSensor/TouchSensorTest/TouchSensorTest.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/07    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 // Me_LimitSwitch module can only be connected to PORT_3, PORT_4, PORT_6,PORT_7,PORT_8 of base shield
 // or from PORT_3 to PORT_8 of baseboard.

--- a/examples/Me_USBHost/TestUSBHsot/TestUSBHsot.ino
+++ b/examples/Me_USBHost/TestUSBHsot/TestUSBHsot.ino
@@ -28,7 +28,8 @@
  * </pre>
  */
 
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include "SoftwareSerial.h"
 //MeUSBHost usbhost(13,12);
 MeUSBHost usbhost(PORT_3);

--- a/examples/Me_UltrasonicSensor/UltrasonicSensorTest/UltrasonicSensorTest.ino
+++ b/examples/Me_UltrasonicSensor/UltrasonicSensorTest/UltrasonicSensorTest.ino
@@ -15,7 +15,8 @@
  * Mark Yan     2015/09/01    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 
 MeUltrasonicSensor ultraSensor(PORT_7); /* Ultrasonic module can ONLY be connected to port 3, 4, 6, 7, 8 of base shield. */
 

--- a/examples/Me_Voice/MeVoiceTest/MeVoiceTest.ino
+++ b/examples/Me_Voice/MeVoiceTest/MeVoiceTest.ino
@@ -14,7 +14,8 @@
  * Mark Yan     2015/12/15    1.0.0          Build the new
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 #include "MeVoice.h"
 

--- a/examples/Me_Wifi/MeWifi/MeWifi.ino
+++ b/examples/Me_Wifi/MeWifi/MeWifi.ino
@@ -16,7 +16,8 @@
  * Mark Yan     2015/09/09    1.0.0          rebuild the old lib
  * </pre>
  */
-#include "MeOrion.h"
+#define MeOrion_H
+#include <Makeblock.h>
 #include <SoftwareSerial.h>
 
 MeWifi Wifi(PORT_4);

--- a/src/Makeblock.h
+++ b/src/Makeblock.h
@@ -1,0 +1,16 @@
+/**
+ * This file is used to decide whether the driver for the MCore or the MeOrion board
+ * should be used.
+ */
+
+/*
+ * Code that is meant to be used on the Orion should define the MeOrion_H
+ * constant, whereas code for the MCore should define the MeMCore_H constant.
+ */
+#if defined(MeOrion_H)
+    #include "MeOrion.h"
+#elif defined(MeMCore_H)
+    #include "MeMCore.h"
+#elif defined(MeShield_H)
+    #include "MeShield.h"
+#endif

--- a/src/MeMCore.h
+++ b/src/MeMCore.h
@@ -30,8 +30,7 @@
  * Mark Yan         2015/11/09     1.0.1            fix some comments error.
  * </pre>
  */
-#ifndef MeMCore_H
-#define MeMCore_H
+#ifdef MeMCore_H
 
 #include <Arduino.h>
 #include "MeConfig.h"
@@ -77,4 +76,3 @@ MePort_Sig mePort[15] =
   {  5,  4 }, { NC, NC }, { NC, NC }, { NC, NC }, { NC, NC },
 };
 #endif // MeMCore_H
-

--- a/src/MeOrion.h
+++ b/src/MeOrion.h
@@ -29,8 +29,7 @@
  * Rafael Lee       2015/09/02     1.0.1            Added some comments and macros.
  * </pre>
  */
-#ifndef MeOrion_H
-#define MeOrion_H
+#ifdef MeOrion_H
 
 #include <Arduino.h>
 #include "MeConfig.h"


### PR DESCRIPTION
### ChangeLog

A new header file was introduced (Makeblock.h) which can be used to address the whole library. This modification was necessary for [codebender](https://codebender.cc) compatibility. That is because every library hosted by codebender, can be registered to its library management system using **only one** header file.
In this case, the header used to address the library would either be `MeMCore.h` or `MeOrion.h`. Using one of the two would mean that the examples using the other header file would fail compiling with a `file-not-found` error.
This PR fixes this issue using one main header file for the library, and deciding which of the `MeMCore.h`, `MeOrion.h` or `MeShield.h` will be used based on constants defined in examples.
