### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=MakeBlock <www.makeblock.cc>
 sentence= Use to drive all devices provided by Makeblock company.
 paragraph=This library allows an Arduino board to control all devices provided by Makeblock company.
 category=Device Control
-url=www.makeblock.cc
+url=https://www.makeblock.cc
 architectures=*


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.